### PR TITLE
Add `freesurfer -qcache` CIFTI outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ input_datasets:
 bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--subject-id"
     $SESSION_SELECTION_FLAG: "--session-id"
+    $RUN_SELECTION_FLAG: "--run-id"
     -w: "$BABS_TMPDIR"
     --subjects-dir: "${PWD}/inputs/data/fmriprep_anat/fmriprep_anat/sourcedata/freesurfer"
     --fs-license-file: "/path/to/FreeSurfer/license.txt" # [FIX ME] path to 
@@ -145,8 +146,35 @@ freesurfer-post /path/to/subjects_dir /path/to/output participant --subject-id s
 
 # Process a specific session
 freesurfer-post /path/to/subjects_dir /path/to/output --subject-id sub-01 --session-id ses-01
+
+# Process a specific run (or fall back to the session/subject directory)
+freesurfer-post /path/to/subjects_dir /path/to/output --subject-id sub-01 --session-id ses-01 --run-id run-01
 ```
 
+### Directory resolution precedence
+
+- Subject directory: `sub-XX`
+- Session directory: `sub-XX_ses-YY`
+- Run directory: `sub-XX[_ses-YY]_run-ZZ`
+
+Resolution order is: run (most specific) > session > subject. If a more specific directory does not exist, processing falls back to the next available level with a warning.
+
+### CIFTI outputs
+
+The workflow runs FreeSurfer's qcache step and converts each paired hemispheric
+vertex measure to an fsLR 164k CIFTI dense scalar. The files use BIDS entities
+and are written with JSON sidecars in the subject's final output directory. For
+example:
+
+```text
+sub-01/sub-01_ses-01_run-01_space-fsLR_den-164k_desc-fwhm10_thickness.dscalar.nii
+sub-01/sub-01_ses-01_run-01_space-fsLR_den-164k_desc-fwhm10_thickness.json
+```
+
+The CIFTI outputs include `area`, `areaPial`, `curv`, `JacobianWhite`, `sulc`,
+`thickness`, `volume`, `whiteH`, and `whiteK`, each with the native and qcache
+smoothed (`desc-fwhm0`, `desc-fwhm5`, `desc-fwhm10`, `desc-fwhm15`,
+`desc-fwhm20`, and `desc-fwhm25`) variants.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,25 +29,25 @@ import pandas as pd
 
 # Load the tsvs into dataframes.
 fspost_data = pd.read_csv(
-    "sub-01_atlas-Schaefer2018100Parcels7Networks_surfacestats.tsv", 
-    sep = "\t",
+    'sub-01_atlas-Schaefer2018100Parcels7Networks_surfacestats.tsv',
+    sep='\t',
 )
 xcpd_reho = pd.read_csv(
-    "sub-01_task-emotion_dir-LR_run-1_space-fsLR_seg-4S156Parcels_stat-reho_bold.tsv", 
-    sep = "\t",
+    'sub-01_task-emotion_dir-LR_run-1_space-fsLR_seg-4S156Parcels_stat-reho_bold.tsv',
+    sep='\t',
 )
 
 # Convert xcpd_reho from wide to long format
 xcpd_reho_long = pd.melt(
-  xcpd_reho, 
-  var_name="StructName", 
-  value_name="reho",
+    xcpd_reho,
+    var_name='StructName',
+    value_name='reho',
 )
 # Prepend the string "7Networks_" to match the annot StructName
-xcpd_reho_long["StructName"] = "7Networks_" + xcpd_reho_long["StructName"]
+xcpd_reho_long['StructName'] = '7Networks_' + xcpd_reho_long['StructName']
 
 # Merge fspost_data with xcpd_reho_long, keeping all rows from both datasets
-merged_data = pd.merge(fspost_data, xcpd_reho_long, on="StructName")
+merged_data = pd.merge(fspost_data, xcpd_reho_long, on='StructName')
 ```
 
 ### R Example

--- a/freesurfer_post/cli.py
+++ b/freesurfer_post/cli.py
@@ -16,9 +16,10 @@ from .workflows import build_workflow
 @click.option('--subjects-dir', type=click.Path(exists=True))
 @click.option('--subject-id', '-s', help='Subject ID to process')
 @click.option('--session-id', '-x', help='Session ID to process')
+@click.option('--run-id', '-r', help='Run ID to process')
 @click.option('--working-dir', '-w', help='Path to working directory')
 @click.option('--fs-license-file', '-l', help='Path to license file')
-def main(
+def main(  # noqa: PLR0917
     verbose,
     input_path,
     output_path,
@@ -26,6 +27,7 @@ def main(
     subjects_dir,
     subject_id,
     session_id,
+    run_id,
     working_dir,
     fs_license_file,
 ):
@@ -44,11 +46,12 @@ def main(
         click.echo('Verbose mode enabled')
 
     # Get the subject's freesurfer directory
-    subject_fs_dir = find_freesurfer_dir(subjects_dir, subject_id, session_id)
+    subject_fs_dir = find_freesurfer_dir(subjects_dir, subject_id, session_id, run_id)
 
     click.echo(f'Processing {input_path} -> {output_path}')
     click.echo(f'Subject ID: {subject_id}')
     click.echo(f'Session ID: {session_id}')
+    click.echo(f'Run ID: {run_id}')
     click.echo(f'Subject directory: {subject_fs_dir}')
     click.echo(f'Processing level: {processing_level}')
     click.echo(f'Working directory: {working_dir}')
@@ -57,6 +60,7 @@ def main(
     workflow = build_workflow(
         subject_id=subject_id,
         session_id=session_id,
+        run_id=run_id,
         subject_freesurfer_dir=subject_fs_dir,
         output_dir=output_path,
         working_dir=working_dir,

--- a/freesurfer_post/data/__init__.py
+++ b/freesurfer_post/data/__init__.py
@@ -1,1 +1,1 @@
-"""Data module for freesurfer-post package.""" 
+"""Data module for freesurfer-post package."""

--- a/freesurfer_post/data/surfacestats.json
+++ b/freesurfer_post/data/surfacestats.json
@@ -5,6 +5,9 @@
     "session_id": {
       "Description": "BIDS session ID"
     },
+    "run_id": {
+      "Description": "BIDS run ID"
+    },
     "atlas": {
       "Description": "Atlas used for parcellation"
     },

--- a/freesurfer_post/interfaces/__init__.py
+++ b/freesurfer_post/interfaces/__init__.py
@@ -1,2 +1,3 @@
+from .cifti import QcacheToCifti  # noqa: F401
 from .interfaces import SurfStatsMetadata  # noqa: F401
 from .tabular import FSStats, SummarizeRegionStats  # noqa: F401

--- a/freesurfer_post/interfaces/cifti.py
+++ b/freesurfer_post/interfaces/cifti.py
@@ -1,0 +1,159 @@
+"""Interfaces for converting FreeSurfer qcache metrics to CIFTI files."""
+
+import json
+import os
+from pathlib import Path
+from subprocess import run as run_command
+
+from nipype.interfaces.base import (
+    File,
+    OutputMultiPath,
+    SimpleInterface,
+    TraitedSpec,
+    isdefined,
+    traits,
+)
+
+from ..utils import (
+    build_cifti_metadata,
+    build_cifti_output_name,
+    build_cifti_sidecar_name,
+    build_output_prefix,
+    find_qcache_metric_pairs,
+)
+
+
+class _QcacheToCiftiInputSpec(TraitedSpec):
+    subject_id = traits.Str(desc='BIDS subject ID', mandatory=True)
+    session_id = traits.Str(desc='BIDS session ID', mandatory=False)
+    run_id = traits.Str(desc='BIDS run ID', mandatory=False)
+    freesurfer_id = traits.Str(desc='FreeSurfer directory name', mandatory=True)
+    subjects_dir = traits.Directory(
+        desc='Path to the FreeSurfer subjects directory',
+        exists=True,
+        mandatory=True,
+    )
+    output_dir = traits.Directory(
+        desc='Path to the final output directory',
+        exists=True,
+        mandatory=True,
+    )
+
+
+class _QcacheToCiftiOutputSpec(TraitedSpec):
+    out_files = OutputMultiPath(
+        File(exists=True),
+        desc='fsLR 164k CIFTI dense scalar files',
+    )
+    out_jsons = OutputMultiPath(
+        File(exists=True),
+        desc='JSON sidecars for the fsLR 164k CIFTI dense scalar files',
+    )
+
+
+def _get_fsaverage_white(subjects_dir: Path, hemi: str) -> Path:
+    """Locate the fsaverage white surface used by ``mris_convert``."""
+    candidates = [subjects_dir / 'fsaverage' / 'surf' / f'{hemi}.white']
+    freesurfer_home = os.getenv('FREESURFER_HOME')
+    if freesurfer_home:
+        candidates.append(
+            Path(freesurfer_home) / 'subjects' / 'fsaverage' / 'surf' / f'{hemi}.white'
+        )
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    searched = ', '.join(str(candidate) for candidate in candidates)
+    raise FileNotFoundError(
+        f'Could not find the fsaverage {hemi} white surface: {searched}'
+    )
+
+
+def _resample_to_fslr(in_file: Path, out_file: Path, hemi: str) -> None:
+    """Resample one fsaverage metric to fsLR 164k with neuromaps."""
+    from neuromaps.transforms import fsaverage_to_fslr
+
+    (resampled_image,) = fsaverage_to_fslr(
+        str(in_file),
+        target_density='164k',
+        hemi=hemi,
+        method='linear',
+    )
+    resampled_image.to_filename(out_file)
+
+
+class QcacheToCifti(SimpleInterface):
+    """Convert paired FreeSurfer qcache metrics to fsLR 164k CIFTIs."""
+
+    input_spec = _QcacheToCiftiInputSpec
+    output_spec = _QcacheToCiftiOutputSpec
+
+    def _run_interface(self, runtime):
+        subjects_dir = Path(self.inputs.subjects_dir)
+        surface_dir = subjects_dir / self.inputs.freesurfer_id / 'surf'
+        metric_pairs = find_qcache_metric_pairs(surface_dir)
+
+        session_id = (
+            self.inputs.session_id if isdefined(self.inputs.session_id) else None
+        )
+        run_id = self.inputs.run_id if isdefined(self.inputs.run_id) else None
+        output_prefix = build_output_prefix(
+            self.inputs.subject_id,
+            session_id,
+            run_id,
+        )
+        output_dir = Path(self.inputs.output_dir) / self.inputs.subject_id
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        work_dir = Path(runtime.cwd)
+        fsaverage_surfaces = {
+            hemi: _get_fsaverage_white(subjects_dir, hemi) for hemi in ('lh', 'rh')
+        }
+        out_files = []
+        out_jsons = []
+        for metric, lh_mgh, rh_mgh in metric_pairs:
+            resampled_metrics = {}
+            for hemi, mgh_file, neuromaps_hemi in (
+                ('lh', lh_mgh, 'L'),
+                ('rh', rh_mgh, 'R'),
+            ):
+                fsaverage_gii = work_dir / f'{hemi}.{metric}.fsaverage.shape.gii'
+                fslr_gii = work_dir / f'{hemi}.{metric}.fsLR_den-164k.shape.gii'
+                run_command(
+                    [
+                        'mris_convert',
+                        '-c',
+                        str(mgh_file),
+                        str(fsaverage_surfaces[hemi]),
+                        str(fsaverage_gii),
+                    ],
+                    check=True,
+                )
+                _resample_to_fslr(fsaverage_gii, fslr_gii, neuromaps_hemi)
+                resampled_metrics[hemi] = fslr_gii
+
+            cifti_file = output_dir / build_cifti_output_name(output_prefix, metric)
+            run_command(
+                [
+                    'wb_command',
+                    '-cifti-create-dense-scalar',
+                    str(cifti_file),
+                    '-left-metric',
+                    str(resampled_metrics['lh']),
+                    '-right-metric',
+                    str(resampled_metrics['rh']),
+                ],
+                check=True,
+            )
+            out_files.append(str(cifti_file))
+
+            sidecar_file = output_dir / build_cifti_sidecar_name(cifti_file.name)
+            with sidecar_file.open('w') as sidecar:
+                json.dump(build_cifti_metadata(metric), sidecar, indent=2)
+                sidecar.write('\n')
+            out_jsons.append(str(sidecar_file))
+
+        self._results['out_files'] = out_files
+        self._results['out_jsons'] = out_jsons
+        return runtime

--- a/freesurfer_post/interfaces/tabular.py
+++ b/freesurfer_post/interfaces/tabular.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, isdefined, traits
 
-from ..utils import find_freesurfer_dir
+from ..utils import build_output_prefix, find_freesurfer_dir
 
 """Compile FreeSurfer stats files."""
 
@@ -16,6 +16,7 @@ NOSUFFIX_COLS = ['Index', 'SegId', 'StructName']
 ASEG_STATS_METADATA = {
     'participant_id': {'Description': 'BIDS participant ID'},
     'session_id': {'Description': 'BIDS session ID'},
+    'run_id': {'Description': 'BIDS run ID'},
     'name': {'Description': 'Name of the structure'},
     'nvoxels': {
         'Description': 'Number of voxels in the structure. Originally NVoxels.'
@@ -64,6 +65,10 @@ class _SummarizeRegionStatsInputSpec(TraitedSpec):
     )
     session_id = traits.Str(
         desc='Session ID',
+        mandatory=False,
+    )
+    run_id = traits.Str(
+        desc='Run ID',
         mandatory=False,
     )
     atlas_name = traits.Str(
@@ -132,10 +137,12 @@ class SummarizeRegionStats(SimpleInterface):
 
         out_df = pd.concat(surfstat_dfs, axis=0, ignore_index=True)
 
-        # The freesurfer directory may contain subject and session. check here
+        # The freesurfer directory may contain subject and session/run. check here
         session_id = (
             None if not isdefined(self.inputs.session_id) else self.inputs.session_id
         )
+        run_id = None if not isdefined(self.inputs.run_id) else self.inputs.run_id
+        out_df.insert(0, 'run_id', run_id)
         out_df.insert(0, 'session_id', session_id)
         out_df.insert(0, 'subject_id', self.inputs.subject_id)
 
@@ -155,7 +162,7 @@ class SummarizeRegionStats(SimpleInterface):
         sanity_check_columns('SurfArea', 'Area_mm2_wgpct', 1)
         output_dir = Path(self.inputs.output_dir) / subject_id
         output_dir.mkdir(parents=True, exist_ok=True)
-        output_prefix = f'{subject_id}_{session_id}' if session_id else subject_id
+        output_prefix = build_output_prefix(subject_id, session_id, run_id)
 
         cleaned_atlas_name = (
             atlas.replace('.', '').replace('_order', '').replace('_', '')
@@ -330,6 +337,10 @@ class _FSStatsInputSpec(TraitedSpec):
         desc='Session ID',
         mandatory=False,
     )
+    run_id = traits.Str(
+        desc='Run ID',
+        mandatory=False,
+    )
     subjects_dir = traits.Directory(
         desc='Path to ${SUBJECTS_DIR}',
         exists=True,
@@ -358,12 +369,14 @@ class FSStats(SimpleInterface):
         session_id = (
             self.inputs.session_id if isdefined(self.inputs.session_id) else None
         )
+        run_id = self.inputs.run_id if isdefined(self.inputs.run_id) else None
         subjects_dir = Path(self.inputs.subjects_dir)
-        fs_dir = find_freesurfer_dir(subjects_dir, subject_id, session_id)
+        fs_dir = find_freesurfer_dir(subjects_dir, subject_id, session_id, run_id)
 
         fs_audit = {
             'subject_id': {'value': subject_id, 'meta': 'BIDS subject id'},
             'session_id': {'value': session_id, 'meta': 'BIDS session id'},
+            'run_id': {'value': run_id, 'meta': 'BIDS run id'},
         }
         fs_audit.update(get_euler_from_log(fs_dir / 'scripts' / 'recon-all.log'))
 
@@ -392,7 +405,7 @@ class FSStats(SimpleInterface):
         # Write the outputs
         output_dir = Path(self.inputs.output_dir) / subject_id
         output_dir.mkdir(parents=True, exist_ok=True)
-        output_prefix = f'{subject_id}_{session_id}' if session_id else subject_id
+        output_prefix = build_output_prefix(subject_id, session_id, run_id)
         atlas_tsv = output_dir / f'{output_prefix}_seg-FreeSurfer_morph.tsv'
         whole_brain_tsv = output_dir / f'{output_prefix}_desc-FreeSurfer_qc.tsv'
         atlas_json = output_dir / f'{output_prefix}_seg-FreeSurfer_morph.json'
@@ -412,7 +425,7 @@ class FSStats(SimpleInterface):
         data_df = pd.DataFrame([data_value])
 
         cols = data_df.columns.tolist()
-        id_cols = ['participant_id', 'session_id']
+        id_cols = ['participant_id', 'session_id', 'run_id']
         id_cols = [col for col in id_cols if col in cols]
 
         # Split data_df into two dataframes, one for the atlas and one for the whole brain measures

--- a/freesurfer_post/utils.py
+++ b/freesurfer_post/utils.py
@@ -3,9 +3,179 @@
 import warnings
 from pathlib import Path
 
+# FreeSurfer qcache metrics that are converted to CIFTI. The names on the
+# right are intentionally stable derivative suffixes; qcache's dots and
+# underscores are not valid BIDS suffix characters.
+QCACHE_CIFTI_METRICS = {
+    'area': {
+        'suffix': 'area',
+        'description': 'vertex-wise cortical surface area',
+        'units': 'mm^2',
+    },
+    'area.pial': {
+        'suffix': 'areaPial',
+        'description': 'vertex-wise cortical pial surface area',
+        'units': 'mm^2',
+    },
+    'curv': {
+        'suffix': 'curv',
+        'description': 'cortical surface curvature',
+        'units': 'mm^-1',
+    },
+    'jacobian_white': {
+        'suffix': 'JacobianWhite',
+        'description': 'Jacobian determinant of the white-surface registration',
+        'units': '1',
+    },
+    'sulc': {
+        'suffix': 'sulc',
+        'description': 'sulcal depth',
+        'units': 'mm',
+    },
+    'thickness': {
+        'suffix': 'thickness',
+        'description': 'cortical thickness',
+        'units': 'mm',
+    },
+    'volume': {
+        'suffix': 'volume',
+        'description': 'vertex-wise cortical volume',
+        'units': 'mm^3',
+    },
+    'white.H': {
+        'suffix': 'whiteH',
+        'description': 'mean curvature of the white surface',
+        'units': 'mm^-1',
+    },
+    'white.K': {
+        'suffix': 'whiteK',
+        'description': 'Gaussian curvature of the white surface',
+        'units': 'mm^-2',
+    },
+}
+
+
+def build_output_prefix(
+    subject_id: str,
+    session_id: str | None = None,
+    run_id: str | None = None,
+) -> str:
+    """Build the subject/session/run prefix used by output files."""
+    entities = [subject_id]
+    if session_id:
+        entities.append(session_id)
+    if run_id:
+        entities.append(run_id)
+    return '_'.join(entities)
+
+
+def find_qcache_metric_pairs(
+    surface_dir: str | Path,
+) -> list[tuple[str, Path, Path]]:
+    """Find paired hemispheric qcache metrics in fsaverage space.
+
+    Returns tuples containing the metric name, left-hemisphere file, and
+    right-hemisphere file. An incomplete pair is treated as an error because a
+    cortical dense scalar must contain both hemispheres.
+    """
+    surface_dir = Path(surface_dir)
+    suffix = '.fsaverage.mgh'
+    hemispheric_files: dict[str, dict[str, Path]] = {'lh': {}, 'rh': {}}
+
+    for hemi in hemispheric_files:
+        for metric_file in surface_dir.glob(f'{hemi}.*{suffix}'):
+            metric = metric_file.name[len(f'{hemi}.') : -len(suffix)]
+            if parse_qcache_metric(metric) is not None:
+                hemispheric_files[hemi][metric] = metric_file
+
+    left_metrics = set(hemispheric_files['lh'])
+    right_metrics = set(hemispheric_files['rh'])
+    incomplete_metrics = left_metrics.symmetric_difference(right_metrics)
+    if incomplete_metrics:
+        metrics = ', '.join(sorted(incomplete_metrics))
+        raise FileNotFoundError(f'Unpaired fsaverage qcache metrics: {metrics}')
+
+    if not left_metrics:
+        raise FileNotFoundError(f'No fsaverage qcache metrics found in {surface_dir}')
+
+    return [
+        (
+            metric,
+            hemispheric_files['lh'][metric],
+            hemispheric_files['rh'][metric],
+        )
+        for metric in sorted(left_metrics)
+    ]
+
+
+def build_cifti_output_name(output_prefix: str, metric: str) -> str:
+    """Build the BIDS filename for an fsLR 164k qcache dense scalar."""
+    parsed_metric = parse_qcache_metric(metric)
+    if parsed_metric is None:
+        raise ValueError(f'Unsupported qcache metric: {metric}')
+
+    _, metric_info, smoothing_fwhm = parsed_metric
+    entities = [output_prefix, 'space-fsLR', 'den-164k']
+    if smoothing_fwhm is not None:
+        entities.append(f'desc-fwhm{smoothing_fwhm}')
+    return f'{"_".join(entities)}_{metric_info["suffix"]}.dscalar.nii'
+
+
+def build_cifti_sidecar_name(cifti_name: str) -> str:
+    """Build the JSON sidecar filename corresponding to a CIFTI filename."""
+    if not cifti_name.endswith('.dscalar.nii'):
+        raise ValueError(f'Not a dense-scalar CIFTI filename: {cifti_name}')
+    return f'{cifti_name.removesuffix(".dscalar.nii")}.json'
+
+
+def build_cifti_metadata(metric: str) -> dict[str, str | int]:
+    """Build metadata for a qcache-derived fsLR CIFTI dense scalar."""
+    parsed_metric = parse_qcache_metric(metric)
+    if parsed_metric is None:
+        raise ValueError(f'Unsupported qcache metric: {metric}')
+
+    _, metric_info, smoothing_fwhm = parsed_metric
+    metadata: dict[str, str | int] = {
+        'Description': (
+            f'FreeSurfer {metric_info["description"]}, resampled from fsaverage '
+            'to fsLR at 164k surface density.'
+        ),
+        'Units': metric_info['units'],
+    }
+    if smoothing_fwhm is not None:
+        metadata['SmoothingFWHM'] = smoothing_fwhm
+        metadata['SmoothingFWHMUnits'] = 'mm'
+    return metadata
+
+
+def parse_qcache_metric(
+    metric: str,
+) -> tuple[str, dict[str, str], int | None] | None:
+    """Parse a supported qcache metric and its optional smoothing level.
+
+    ``pial_lgi`` and any other unsupported qcache products are intentionally
+    excluded from CIFTI generation.
+    """
+    base_metric, separator, smoothing_label = metric.rpartition('.fwhm')
+    if separator:
+        if not smoothing_label.isdecimal():
+            return None
+        smoothing_fwhm = int(smoothing_label)
+    else:
+        base_metric = metric
+        smoothing_fwhm = None
+
+    metric_info = QCACHE_CIFTI_METRICS.get(base_metric)
+    if metric_info is None:
+        return None
+    return base_metric, metric_info, smoothing_fwhm
+
 
 def find_freesurfer_dir(
-    subjects_dir: str | Path, subject_id: str, session_id: str | None = None
+    subjects_dir: str | Path,
+    subject_id: str,
+    session_id: str | None = None,
+    run_id: str | None = None,
 ) -> Path:
     """Find a valid FreeSurfer subject directory in a directory.
 
@@ -17,6 +187,8 @@ def find_freesurfer_dir(
         Subject identifier
     session_id : str, optional
         Session identifier
+    run_id : str, optional
+        Run identifier
 
     Returns
     -------
@@ -28,20 +200,42 @@ def find_freesurfer_dir(
     if not subjects_dir.exists():
         raise FileNotFoundError(f'Subjects directory {subjects_dir} does not exist')
 
-    warn_no_session = False
-    if session_id is not None:
-        if (subjects_dir / f'{subject_id}_{session_id}').exists():
-            return subjects_dir / f'{subject_id}_{session_id}'
-        warn_no_session = True
+    preferred_candidate = None
 
-    if (subjects_dir / subject_id).exists():
-        if warn_no_session:
+    # Most specific: subject[_session]_run.
+    if run_id is not None:
+        entities = [subject_id]
+        if session_id is not None:
+            entities.append(session_id)
+        entities.append(run_id)
+        candidate = subjects_dir / '_'.join(entities)
+        preferred_candidate = candidate
+        if candidate.exists():
+            return candidate
+
+    # Next: subject_session.
+    if session_id is not None:
+        candidate = subjects_dir / f'{subject_id}_{session_id}'
+        if preferred_candidate is None:
+            preferred_candidate = candidate
+        if candidate.exists():
+            if preferred_candidate != candidate:
+                warnings.warn(
+                    f'{preferred_candidate} not found; using {candidate} instead',
+                    stacklevel=2,
+                )
+            return candidate
+
+    # Fallback: subject.
+    candidate = subjects_dir / subject_id
+    if candidate.exists():
+        if preferred_candidate is not None:
             warnings.warn(
-                f'{subjects_dir}/{subject_id}_{session_id} not found in {subjects_dir}'
-                f' using {subjects_dir}/{subject_id} instead',
+                f'{preferred_candidate} not found; using {candidate} instead',
                 stacklevel=2,
             )
-        return subjects_dir / subject_id
+        return candidate
+
     raise FileNotFoundError(
-        f'No directory found for subject: {subject_id}, session: {session_id}'
+        f'No directory found for subject: {subject_id}, session: {session_id}, run: {run_id}'
     )

--- a/freesurfer_post/workflows.py
+++ b/freesurfer_post/workflows.py
@@ -5,7 +5,12 @@ import nipype.pipeline.engine as pe
 from nipype.interfaces import freesurfer as fs
 from nipype.interfaces.base import traits
 
-from .interfaces import FSStats, SummarizeRegionStats, SurfStatsMetadata
+from .interfaces import (
+    FSStats,
+    QcacheToCifti,
+    SummarizeRegionStats,
+    SurfStatsMetadata,
+)
 
 # Directory in the container with the collection of annots
 ANNOTS_DIR = Path('/opt/freesurfer_tabulate/annots/')
@@ -39,19 +44,21 @@ AVAILABLE_PARCELLATIONS = [
 NATIVE_PARCELLATIONS = ['aparc.DKTatlas', 'aparc.a2009s', 'aparc', 'BA_exvivo']
 
 
-def build_workflow(
+def build_workflow(  # noqa: PLR0917
     subject_id: str,
     session_id: str | None,
+    run_id: str | None,
     subject_freesurfer_dir: str | Path,
     output_dir: str | Path,
     working_dir: str | Path,
 ):
     subject_freesurfer_dir = Path(subject_freesurfer_dir)
     subjects_dir = str(subject_freesurfer_dir.parent)
+    freesurfer_id = subject_freesurfer_dir.name
     output_dir = Path(output_dir)
     working_dir = Path(working_dir)
 
-    workflow = pe.Workflow(name=f'freesurfer_post_{subject_id}')
+    workflow = pe.Workflow(name=f'freesurfer_post_{freesurfer_id}')
     workflow.base_dir = working_dir
     workflow.config['execution'] = {'crashdump_dir': output_dir / 'crash'}
     workflow.config['execution']['crashdump_dir'] = output_dir / 'crash'
@@ -59,18 +66,27 @@ def build_workflow(
 
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['subject_id', 'session_id', 'fs_subjects_dir', 'output_dir'],
+            fields=[
+                'subject_id',
+                'session_id',
+                'run_id',
+                'freesurfer_id',
+                'fs_subjects_dir',
+                'output_dir',
+            ],
         ),
         name='inputnode',
     )
     inputnode.inputs.subject_id = subject_id
     inputnode.inputs.session_id = session_id if session_id else traits.Undefined
+    inputnode.inputs.run_id = run_id if run_id else traits.Undefined
+    inputnode.inputs.freesurfer_id = freesurfer_id
     inputnode.inputs.fs_subjects_dir = subjects_dir
     inputnode.inputs.output_dir = output_dir
 
     for parc_name in AVAILABLE_PARCELLATIONS + NATIVE_PARCELLATIONS:
         parc_wf = init_parcellation_wf(
-            subject_id=subject_id,
+            subject_id=freesurfer_id,
             subject_freesurfer_dir=subject_freesurfer_dir,
             parc_name=parc_name,
         )
@@ -78,6 +94,8 @@ def build_workflow(
             (inputnode, parc_wf, [
                 ('subject_id', 'inputnode.subject_id'),
                 ('session_id', 'inputnode.session_id'),
+                ('run_id', 'inputnode.run_id'),
+                ('freesurfer_id', 'inputnode.freesurfer_id'),
                 ('fs_subjects_dir', 'inputnode.fs_subjects_dir'),
                 ('output_dir', 'inputnode.output_dir'),
             ]),
@@ -89,8 +107,31 @@ def build_workflow(
         (inputnode, fs_stats, [
             ('subject_id', 'subject_id'),
             ('session_id', 'session_id'),
+            ('run_id', 'run_id'),
             ('fs_subjects_dir', 'subjects_dir'),
             ('output_dir', 'output_dir'),
+        ]),
+    ])  # fmt:skip
+
+    # Generate fsaverage qcache metrics, then resample and combine them as
+    # fsLR 164k CIFTI dense scalar files in the final output directory.
+    qcache = pe.Node(fs.ReconAll(directive='qcache'), name='qcache')
+    qcache.interface.force_run = True
+    qcache_to_cifti = pe.Node(QcacheToCifti(), name='qcache_to_cifti')
+    workflow.connect([
+        (inputnode, qcache, [
+            ('freesurfer_id', 'subject_id'),
+            ('fs_subjects_dir', 'subjects_dir'),
+        ]),
+        (inputnode, qcache_to_cifti, [
+            ('subject_id', 'subject_id'),
+            ('session_id', 'session_id'),
+            ('run_id', 'run_id'),
+            ('output_dir', 'output_dir'),
+        ]),
+        (qcache, qcache_to_cifti, [
+            ('subject_id', 'freesurfer_id'),
+            ('subjects_dir', 'subjects_dir'),
         ]),
     ])  # fmt:skip
 
@@ -106,7 +147,7 @@ def init_parcellation_wf(
     Parameters
     ----------
     subject_id : str
-        Subject ID. Needed to construct the bizarre input for SegStats.
+        FreeSurfer directory name. Needed to construct the SegStats input.
     subject_freesurfer_dir : str | Path
         Path to the subject's FreeSurfer directory. May include session.
     parc_name : str
@@ -118,6 +159,8 @@ def init_parcellation_wf(
         Subject ID.
     session_id : str | None
         Session ID.
+    run_id : str | None
+        Run ID.
     fs_subjects_dir : str
         Path to the subjects directory.
     output_dir : str | Path
@@ -130,10 +173,18 @@ def init_parcellation_wf(
     """
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['subject_id', 'session_id', 'fs_subjects_dir', 'output_dir'],
+            fields=[
+                'subject_id',
+                'session_id',
+                'run_id',
+                'freesurfer_id',
+                'fs_subjects_dir',
+                'output_dir',
+            ],
         ),
         name='inputnode',
     )
+    freesurfer_id = subject_id
     clean_parc_name = parc_name.replace('.', '').replace('_', '')
     workflow = pe.Workflow(name=f'parcellation_{clean_parc_name}')
 
@@ -152,6 +203,7 @@ def init_parcellation_wf(
         (inputnode, collect_stats, [
             ('subject_id', 'subject_id'),
             ('session_id', 'session_id'),
+            ('run_id', 'run_id'),
             ('fs_subjects_dir', 'subjects_dir'),
             ('output_dir', 'output_dir'),
         ]),
@@ -220,7 +272,7 @@ def init_parcellation_wf(
                 in_file=str(
                     subject_freesurfer_dir / 'surf' / f'{hemi}.w-g.pct.mgh',
                 ),
-                annot=(subject_id, hemi, parc_name),
+                annot=(freesurfer_id, hemi, parc_name),
                 calc_snr=True,
                 summary_file=gwr_stats_file,
             ),
@@ -229,11 +281,11 @@ def init_parcellation_wf(
 
         workflow.connect([
             (inputnode, transform_nodes[hemi], [
-                ('subject_id', 'target_subject'),
+                ('freesurfer_id', 'target_subject'),
                 ('fs_subjects_dir', 'subjects_dir'),
             ]),
             (inputnode, parc_stats_nodes[hemi], [
-                ('subject_id', 'subject_id'),
+                ('freesurfer_id', 'subject_id'),
                 ('fs_subjects_dir', 'subjects_dir'),
             ]),
             (inputnode, gwr_seg_stats_nodes[hemi], [('fs_subjects_dir', 'subjects_dir')]),

--- a/tests/test_cifti_interface.py
+++ b/tests/test_cifti_interface.py
@@ -1,0 +1,73 @@
+"""Tests for the qcache-to-CIFTI interface."""
+
+import json
+from pathlib import Path
+
+from freesurfer_post.interfaces import cifti
+
+
+def _touch(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+
+def test_qcache_to_cifti_writes_to_final_output(tmp_path, monkeypatch):
+    subjects_dir = tmp_path / 'subjects'
+    freesurfer_id = 'sub-01_ses-02_run-03'
+    surface_dir = subjects_dir / freesurfer_id / 'surf'
+    output_dir = tmp_path / 'output'
+    work_dir = tmp_path / 'work'
+    output_dir.mkdir()
+    work_dir.mkdir()
+
+    for hemi in ('lh', 'rh'):
+        _touch(surface_dir / f'{hemi}.thickness.fwhm10.fsaverage.mgh')
+        _touch(subjects_dir / 'fsaverage' / 'surf' / f'{hemi}.white')
+    _touch(surface_dir / 'lh.pial_lgi.fsaverage.mgh')
+
+    commands = []
+
+    def fake_run(command, check):
+        assert check is True
+        commands.append(command)
+        if command[0] == 'mris_convert':
+            Path(command[-1]).touch()
+        elif command[0] == 'wb_command':
+            Path(command[2]).touch()
+
+    def fake_resample(in_file, out_file, hemi):
+        assert in_file.exists()
+        assert hemi in ('L', 'R')
+        out_file.touch()
+
+    monkeypatch.setattr(cifti, 'run_command', fake_run)
+    monkeypatch.setattr(cifti, '_resample_to_fslr', fake_resample)
+
+    result = cifti.QcacheToCifti(
+        subject_id='sub-01',
+        session_id='ses-02',
+        run_id='run-03',
+        freesurfer_id=freesurfer_id,
+        subjects_dir=subjects_dir,
+        output_dir=output_dir,
+    ).run(cwd=work_dir)
+
+    expected_file = (
+        output_dir
+        / 'sub-01'
+        / 'sub-01_ses-02_run-03_space-fsLR_den-164k_desc-fwhm10_thickness.dscalar.nii'
+    )
+    expected_sidecar = expected_file.with_name(
+        'sub-01_ses-02_run-03_space-fsLR_den-164k_desc-fwhm10_thickness.json'
+    )
+    assert result.outputs.out_files == str(expected_file)
+    assert result.outputs.out_jsons == str(expected_sidecar)
+    assert expected_file.exists()
+    assert expected_sidecar.exists()
+    assert json.loads(expected_sidecar.read_text())['SmoothingFWHM'] == 10
+    assert [command[0] for command in commands] == [
+        'mris_convert',
+        'mris_convert',
+        'wb_command',
+    ]
+    assert commands[-1][2] == str(expected_file)

--- a/tests/test_cifti_utils.py
+++ b/tests/test_cifti_utils.py
@@ -1,0 +1,169 @@
+"""Tests for CIFTI filename and qcache-pair helpers."""
+
+import pytest
+
+from freesurfer_post.utils import (
+    QCACHE_CIFTI_METRICS,
+    build_cifti_metadata,
+    build_cifti_output_name,
+    build_cifti_sidecar_name,
+    build_output_prefix,
+    find_freesurfer_dir,
+    find_qcache_metric_pairs,
+)
+
+
+@pytest.mark.parametrize(
+    ('subject_id', 'session_id', 'run_id', 'expected'),
+    [
+        ('sub-01', None, None, 'sub-01'),
+        ('sub-01', 'ses-02', None, 'sub-01_ses-02'),
+        ('sub-01', None, 'run-03', 'sub-01_run-03'),
+        ('sub-01', 'ses-02', 'run-03', 'sub-01_ses-02_run-03'),
+    ],
+)
+def test_build_output_prefix(subject_id, session_id, run_id, expected):
+    assert build_output_prefix(subject_id, session_id, run_id) == expected
+
+
+@pytest.mark.parametrize(
+    ('metric', 'expected'),
+    [
+        ('area', 'sub-01_ses-02_space-fsLR_den-164k_area.dscalar.nii'),
+        (
+            'area.pial.fwhm25',
+            'sub-01_ses-02_space-fsLR_den-164k_desc-fwhm25_areaPial.dscalar.nii',
+        ),
+        (
+            'jacobian_white.fwhm0',
+            'sub-01_ses-02_space-fsLR_den-164k_desc-fwhm0_JacobianWhite.dscalar.nii',
+        ),
+        ('curv', 'sub-01_ses-02_space-fsLR_den-164k_curv.dscalar.nii'),
+        ('sulc', 'sub-01_ses-02_space-fsLR_den-164k_sulc.dscalar.nii'),
+        (
+            'thickness.fwhm15',
+            'sub-01_ses-02_space-fsLR_den-164k_desc-fwhm15_thickness.dscalar.nii',
+        ),
+        ('volume', 'sub-01_ses-02_space-fsLR_den-164k_volume.dscalar.nii'),
+        (
+            'white.H.fwhm5',
+            'sub-01_ses-02_space-fsLR_den-164k_desc-fwhm5_whiteH.dscalar.nii',
+        ),
+        (
+            'white.K.fwhm10',
+            'sub-01_ses-02_space-fsLR_den-164k_desc-fwhm10_whiteK.dscalar.nii',
+        ),
+    ],
+)
+def test_build_cifti_output_name(metric, expected):
+    assert build_cifti_output_name('sub-01_ses-02', metric) == expected
+
+
+def test_build_cifti_sidecar_name():
+    assert (
+        build_cifti_sidecar_name('sub-01_space-fsLR_den-164k_thickness.dscalar.nii')
+        == 'sub-01_space-fsLR_den-164k_thickness.json'
+    )
+
+
+def test_build_cifti_metadata_records_smoothing():
+    metadata = build_cifti_metadata('thickness.fwhm10')
+
+    assert metadata == {
+        'Description': (
+            'FreeSurfer cortical thickness, resampled from fsaverage to fsLR '
+            'at 164k surface density.'
+        ),
+        'Units': 'mm',
+        'SmoothingFWHM': 10,
+        'SmoothingFWHMUnits': 'mm',
+    }
+
+
+def test_find_qcache_metric_pairs(tmp_path):
+    expected_metrics = ['area.fwhm0', 'thickness.fwhm10']
+    for hemi in ('lh', 'rh'):
+        for metric in expected_metrics:
+            (tmp_path / f'{hemi}.{metric}.fsaverage.mgh').touch()
+
+    pairs = find_qcache_metric_pairs(tmp_path)
+
+    assert [metric for metric, _, _ in pairs] == expected_metrics
+    assert all(lh_file.name.startswith('lh.') for _, lh_file, _ in pairs)
+    assert all(rh_file.name.startswith('rh.') for _, _, rh_file in pairs)
+
+
+def test_find_qcache_metric_pairs_rejects_unpaired_metric(tmp_path):
+    (tmp_path / 'lh.thickness.fwhm10.fsaverage.mgh').touch()
+
+    with pytest.raises(FileNotFoundError, match='Unpaired.*thickness.fwhm10'):
+        find_qcache_metric_pairs(tmp_path)
+
+
+def test_find_qcache_metric_pairs_ignores_pial_lgi(tmp_path):
+    for hemi in ('lh', 'rh'):
+        (tmp_path / f'{hemi}.thickness.fwhm10.fsaverage.mgh').touch()
+    (tmp_path / 'lh.pial_lgi.fsaverage.mgh').touch()
+
+    pairs = find_qcache_metric_pairs(tmp_path)
+
+    assert [metric for metric, _, _ in pairs] == ['thickness.fwhm10']
+
+
+def test_find_qcache_metric_pairs_includes_all_requested_qcache_outputs(tmp_path):
+    metrics = [
+        metric
+        for source_metric in QCACHE_CIFTI_METRICS
+        for metric in (
+            source_metric,
+            *(f'{source_metric}.fwhm{fwhm}' for fwhm in (0, 5, 10, 15, 20, 25)),
+        )
+    ]
+    for hemi in ('lh', 'rh'):
+        for metric in metrics:
+            (tmp_path / f'{hemi}.{metric}.fsaverage.mgh').touch()
+        (tmp_path / f'{hemi}.pial_lgi.fsaverage.mgh').touch()
+
+    pairs = find_qcache_metric_pairs(tmp_path)
+
+    assert len(pairs) == 63
+    assert all('pial_lgi' not in metric for metric, _, _ in pairs)
+
+
+def test_find_qcache_metric_pairs_rejects_empty_directory(tmp_path):
+    with pytest.raises(FileNotFoundError, match='No fsaverage qcache metrics'):
+        find_qcache_metric_pairs(tmp_path)
+
+
+def test_find_freesurfer_dir_prefers_run(tmp_path):
+    run_dir = tmp_path / 'sub-01_ses-02_run-03'
+    run_dir.mkdir()
+
+    assert find_freesurfer_dir(tmp_path, 'sub-01', 'ses-02', 'run-03') == run_dir
+
+
+def test_find_freesurfer_dir_finds_run_without_session(tmp_path):
+    run_dir = tmp_path / 'sub-01_run-03'
+    run_dir.mkdir()
+
+    assert find_freesurfer_dir(tmp_path, 'sub-01', run_id='run-03') == run_dir
+
+
+def test_find_freesurfer_dir_warns_when_falling_back_to_session(tmp_path):
+    session_dir = tmp_path / 'sub-01_ses-02'
+    session_dir.mkdir()
+
+    with pytest.warns(UserWarning, match='run-03.*using.*ses-02'):
+        result = find_freesurfer_dir(tmp_path, 'sub-01', 'ses-02', 'run-03')
+
+    assert result == session_dir
+
+
+def test_find_freesurfer_dir_warns_when_falling_back_to_subject(tmp_path):
+    subject_dir = tmp_path / 'sub-01'
+    subject_dir.mkdir()
+
+    with pytest.warns(UserWarning, match='ses-02.*using.*sub-01'):
+        result = find_freesurfer_dir(tmp_path, 'sub-01', 'ses-02')
+
+    assert result == subject_dir

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import pytest
-
 from freesurfer_post.core import process_data
 
 
@@ -92,7 +91,6 @@ class TestNeuromapsTransform:
     def test_apply_neuromaps_transform_not_implemented(self):
         """Test that apply_neuromaps_transform raises NotImplementedError."""
         import numpy as np
-
         from freesurfer_post.core import apply_neuromaps_transform
 
         dummy_data = np.array([1, 2, 3])

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,63 @@
+"""Workflow construction tests."""
+
+from freesurfer_post import workflows
+
+
+def _touch(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+
+def test_build_workflow_adds_run_aware_cifti_nodes(tmp_path, monkeypatch):
+    subjects_dir = tmp_path / 'subjects'
+    freesurfer_id = 'sub-01_ses-02_run-03'
+    subject_dir = subjects_dir / freesurfer_id
+    annots_dir = tmp_path / 'annots'
+    output_dir = tmp_path / 'output'
+    working_dir = tmp_path / 'work'
+    output_dir.mkdir()
+    working_dir.mkdir()
+
+    for relative_path in (
+        'mri/wm.mgz',
+        'mri/brainmask.mgz',
+        'mri/aseg.presurf.mgz',
+        'mri/ribbon.mgz',
+        'mri/transforms/talairach.xfm',
+        'surf/lh.white',
+        'surf/rh.white',
+        'surf/lh.pial',
+        'surf/rh.pial',
+        'surf/lh.thickness',
+        'surf/rh.thickness',
+        'surf/lh.w-g.pct.mgh',
+        'surf/rh.w-g.pct.mgh',
+        'label/lh.cortex.label',
+        'label/rh.cortex.label',
+    ):
+        _touch(subject_dir / relative_path)
+
+    for parc_name in workflows.AVAILABLE_PARCELLATIONS:
+        for hemi in ('lh', 'rh'):
+            _touch(annots_dir / f'{hemi}.{parc_name}.annot')
+
+    for parc_name in workflows.NATIVE_PARCELLATIONS:
+        for hemi in ('lh', 'rh'):
+            _touch(subject_dir / 'label' / f'{hemi}.{parc_name}.annot')
+
+    monkeypatch.setattr(workflows, 'ANNOTS_DIR', annots_dir)
+
+    workflow = workflows.build_workflow(
+        subject_id='sub-01',
+        session_id='ses-02',
+        run_id='run-03',
+        subject_freesurfer_dir=subject_dir,
+        output_dir=output_dir,
+        working_dir=working_dir,
+    )
+
+    assert workflow.name == f'freesurfer_post_{freesurfer_id}'
+    assert workflow.get_node('inputnode').inputs.freesurfer_id == freesurfer_id
+    assert workflow.get_node('qcache').interface.inputs.directive == 'qcache'
+    assert workflow.get_node('qcache').interface.force_run is True
+    assert workflow.get_node('qcache_to_cifti') is not None


### PR DESCRIPTION
- Runs `recon-all -qcache`
- Uses fstabulate’s MGH → GIFTI → fsLR-164k resampling → Workbench merge flow.
- Outputs the 63 requested CIFTIs (nine metrics × raw/FWHM variants), excluding `pial_lgi`.
- Also add `--run-id` CLI flag.